### PR TITLE
Replaced `options.client.account!.address` with `options.client.account` in ccip-js/src/api.ts

### DIFF
--- a/packages/ccip-js/src/api.ts
+++ b/packages/ccip-js/src/api.ts
@@ -617,7 +617,7 @@ export const createClient = (): Client => {
 
     const approveTxHash = await writeContract(options.client, {
       chain: options.client.chain,
-      account: options.client.account,
+      account: options.client.account as any,
       abi: IERC20ABI,
       address: options.tokenAddress,
       functionName: 'approve',
@@ -852,7 +852,7 @@ export const createClient = (): Client => {
       address: options.routerAddress,
       functionName: 'ccipSend',
       args: buildArgs(options),
-      account: options.client.account,
+      account: options.client.account as any,
       ...(!options.feeTokenAddress && {
         value: await getFee(options),
       }),
@@ -905,7 +905,7 @@ export const createClient = (): Client => {
       address: options.routerAddress,
       functionName: 'ccipSend',
       args: buildArgs(options),
-      account: options.client.account,
+      account: options.client.account as any,
       ...(!options.feeTokenAddress && {
         value: await getFee(options),
       }),

--- a/packages/ccip-js/src/api.ts
+++ b/packages/ccip-js/src/api.ts
@@ -617,7 +617,7 @@ export const createClient = (): Client => {
 
     const approveTxHash = await writeContract(options.client, {
       chain: options.client.chain,
-      account: options.client.account!.address,
+      account: options.client.account,
       abi: IERC20ABI,
       address: options.tokenAddress,
       functionName: 'approve',
@@ -852,7 +852,7 @@ export const createClient = (): Client => {
       address: options.routerAddress,
       functionName: 'ccipSend',
       args: buildArgs(options),
-      account: options.client.account!.address,
+      account: options.client.account,
       ...(!options.feeTokenAddress && {
         value: await getFee(options),
       }),
@@ -905,7 +905,7 @@ export const createClient = (): Client => {
       address: options.routerAddress,
       functionName: 'ccipSend',
       args: buildArgs(options),
-      account: options.client.account!.address,
+      account: options.client.account,
       ...(!options.feeTokenAddress && {
         value: await getFee(options),
       }),


### PR DESCRIPTION
Using account address instead of the account object when calling the `writeContract` function results in the following error:

```sh
eth_sendTransaction method is not available
```

![approveRouterError](https://github.com/user-attachments/assets/5503aa7b-7020-4a4d-8c0b-a6610cc5f856)

Details about the error can be found in the [Discussions](https://github.com/wevm/viem/discussions/1452) tab of the Viem repository.