### PR TITLE
update ccip-js package README to fix install instructions and not har…

### DIFF
--- a/packages/ccip-js/README.md
+++ b/packages/ccip-js/README.md
@@ -69,19 +69,19 @@ Additionally, after the transfer, you may need to check the transfer status.
 To install the package, use the following command:
 
 ```sh
-npm install @chainlink/ccip-js viem
+npm install @chainlink/ccip-js
 ```
 
 Or with Yarn:
 
 ```sh
-yarn add @chainlink/ccip-js viem
+yarn add @chainlink/ccip-js
 ```
 
 Or with PNPM:
 
 ```sh
-pnpm add @chainlink/ccip-js viem
+pnpm add @chainlink/ccip-js
 ```
 
 ## Usage


### PR DESCRIPTION
…d pin the viem version

that gets installed due (see also GH issue 8) https://github.com/smartcontractkit/ccip-javascript-sdk/issues/8