### PR TITLE
[For Package Deprecation] Migrate to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,7 @@ jobs:
     environment: publish
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout the repo
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -22,13 +23,18 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.19
           always-auth: true
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+        shell: bash
 
       - name: Install PNPM
-        run: npm install -g pnpm@9.4.0
+        run: npm install -g pnpm@10
         shell: bash
 
       - name: Install dependencies
@@ -40,7 +46,6 @@ jobs:
         run: |
           pnpm build-ccip-js
           cd packages/ccip-js
-          pnpm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_CCIP_JS }}
           pnpm publish --no-git-checks --access public
         shell: bash
 
@@ -48,7 +53,6 @@ jobs:
         run: |
           pnpm build-components
           cd packages/ccip-react-components
-          pnpm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_CCIP_REACT_COMPONENTS }}
           pnpm publish --no-git-checks --access public
         shell: bash
 
@@ -57,6 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout the repo
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -64,13 +69,18 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.19
           always-auth: true
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+        shell: bash
 
       - name: Install PNPM
-        run: npm install -g pnpm@9.4.0
+        run: npm install -g pnpm@10
         shell: bash
 
       - name: Install dependencies

--- a/packages/ccip-js/package.json
+++ b/packages/ccip-js/package.json
@@ -2,6 +2,11 @@
   "name": "@chainlink/ccip-js",
   "version": "0.2.7",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/smartcontractkit/ccip-javascript-sdk",
+    "directory": "packages/ccip-js"
+  },
   "main": "dist/api.js",
   "types": "dist/api.d.ts",
   "type": "module",

--- a/packages/ccip-react-components/package.json
+++ b/packages/ccip-react-components/package.json
@@ -2,6 +2,11 @@
   "name": "@chainlink/ccip-react-components",
   "private": false,
   "version": "0.3.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/smartcontractkit/ccip-javascript-sdk",
+    "directory": "packages/ccip-react-components"
+  },
   "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",


### PR DESCRIPTION
- Add id-token: write permission for OIDC authentication
- Upgrade actions/setup-node from v3 to v4 with registry-url
- Add npm@latest install step (required for OIDC support)
- Remove NPM token authentication (pnpm config set _authToken)
- Update pnpm from 9.4.0 to v10
- Add repository metadata to ccip-js and ccip-react-components package.json

This replaces deprecated npm tokens with OIDC-based trusted publishing for improved security and eliminates the need for long-lived tokens.